### PR TITLE
Add defineExpose to Treeselect component

### DIFF
--- a/src/components/Treeselect.vue
+++ b/src/components/Treeselect.vue
@@ -1936,6 +1936,8 @@ const handleRemoteSearch = () => {
   })
 };
 
+defineExpose({clear})
+
 /** Methods END*/
 
 /** Watch */


### PR DESCRIPTION
Integrated defineExpose to the Treeselect component to expose the clear method. This change facilitates external access to the method, improving component flexibility and reusability.